### PR TITLE
fix: make filter work with related fields

### DIFF
--- a/src/daterange/filters.py
+++ b/src/daterange/filters.py
@@ -12,8 +12,8 @@ class FormFilter(FieldListFilter):
     def __init__(self, field, request, params, model, model_admin, field_path):
         super().__init__(field, request, params, model, model_admin, field_path)
         expected = self.expected_parameters()
-        others = {k: v for k, v in request.GET.items() if k not in expected}
-        self.other_query_string = urllib.parse.urlencode(others)
+        self.other_parameters = {k: v for k, v in request.GET.items() if k not in expected}
+        self.other_query_string = urllib.parse.urlencode(self.other_parameters)
         self.form = self.get_form(request)
         self.form.is_valid()
 

--- a/src/daterange/filters.py
+++ b/src/daterange/filters.py
@@ -30,7 +30,7 @@ class FormFilter(FieldListFilter):
 
     def get_form_kwargs(self, request):
         return {
-            "prefix": self.field.name,
+            "prefix": self.field_path,
             "initial": self.get_initial(),
             "data": request.GET or None,
         }
@@ -55,7 +55,7 @@ class DateRangeFilter(FormFilter):
     form_class = DateRangeForm
 
     def form_lookups(self):
-        name = self.field.name
+        name = self.field_path
         return (
             ("%s-start" % name, "%s__gte" % name),
             ("%s-until" % name, "%s__lt" % name),

--- a/src/daterange/templates/admin/daterange/filter_form.html
+++ b/src/daterange/templates/admin/daterange/filter_form.html
@@ -12,6 +12,11 @@
       {{ hidden_field }}
     {% endfor %}
 
+	{#create hidden inputs to preserve values from other filters and search field#}
+	{% for k, v in spec.other_parameters.items %}
+		<input type="hidden" name="{{ k }}" value="{{ v }}">
+    {% endfor %}
+
     {% for field in spec.form.visible_fields %}
       <div class="field{% if field.errors %} error{% endif %}">
           <div>{{ field.label_tag }}</div>


### PR DESCRIPTION
The filter didn't work with date fields of a related model (e.g. `foreignkey__date` instead of `date` directly), because in these cases `self.field.name` only returned `date` and omitted the relational part. Using `field_path` works for both situations.